### PR TITLE
update to serilog 1.2.26 and servicestack 4.0.12

### DIFF
--- a/src/ServiceStack.Logging.Serilog/ServiceStack.Logging.Serilog.csproj
+++ b/src/ServiceStack.Logging.Serilog/ServiceStack.Logging.Serilog.csproj
@@ -32,20 +32,25 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Serilog">
-      <HintPath>..\packages\Serilog.1.2.4\lib\net45\Serilog.dll</HintPath>
+    <Reference Include="Serilog, Version=1.2.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Serilog.1.2.26\lib\net45\Serilog.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.FullNetFx">
-      <HintPath>..\packages\Serilog.1.2.4\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog.FullNetFx, Version=1.2.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Serilog.1.2.26\lib\net45\Serilog.FullNetFx.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Common">
-      <HintPath>..\packages\ServiceStack.Common.3.9.71\lib\net35\ServiceStack.Common.dll</HintPath>
+    <Reference Include="ServiceStack.Common, Version=4.0.12.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\ServiceStack.Common.4.0.12\lib\net40\ServiceStack.Common.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces">
-      <HintPath>..\packages\ServiceStack.Common.3.9.71\lib\net35\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\ServiceStack.Interfaces.4.0.12\lib\net40\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text">
-      <HintPath>..\packages\ServiceStack.Text.3.9.71\lib\net35\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=4.0.12.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\ServiceStack.Text.4.0.12\lib\net40\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/ServiceStack.Logging.Serilog/packages.config
+++ b/src/ServiceStack.Logging.Serilog/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="1.2.4" targetFramework="net45" />
-  <package id="ServiceStack.Common" version="3.9.71" targetFramework="net45" />
-  <package id="ServiceStack.Text" version="3.9.71" targetFramework="net45" />
+  <package id="Serilog" version="1.2.26" targetFramework="net45" />
+  <package id="ServiceStack.Common" version="4.0.12" targetFramework="net45" />
+  <package id="ServiceStack.Interfaces" version="4.0.12" targetFramework="net45" />
+  <package id="ServiceStack.Text" version="4.0.12" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
@nickvane,

Here is a pull request for ServiceStack.Logging.Serilog.  As I'm evaluating ServiceStack, I was glad to see that this project existed, but found that it didn't work when I installed the ServiceStack and Serilog packages into my project.

I simply updated ServiceStack.Logging.Serilog to use the latest versions of these packages.

Thanks!
